### PR TITLE
CoW support via reflinks if available

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ general
 -  ``add_limit_percent`` - Max percent the total torrent size is allowed
    to vary
 -  ``link_type`` - What kind of link should AutoTorrent make? the options are
-   hard and soft.
+   hard, soft and reflink (if supported).
 -  ``scan_mode`` - options are unsplitable, normal and exact. These can be used
    in combination. See the `scan_modes <#scan-modes>`_ section for more information.
 


### PR DESCRIPTION
Basic Copy-on-write support via reflinks, works on Linux & Mac OS.

Actual reflinking code pilfered from here:
https://github.com/iterative/dvc/blob/f4bec650eddc8874b3f7ab2f8b34bc5dfe60fd49/dvc/system.py#L105

No tests added because they will break if not run on XFS, btrfs or APFS filesystems.

Let me know what you think.