### PR TITLE
Add client_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 *.mo
 *.egg-info
 *.egg

--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,8 @@ general
 
 -  ``db`` - Path to the database file
 -  ``store_path`` - Folder where the virtual folders seeded, resides
+-  ``client_path`` - Folder where the virtual folders seeded, resides 
+   inside the torrent client. Defaults to `store_path`
 -  ``ignore_files`` - A comma seperated list of files that should be
    ignored (supports wildcards)
 -  ``add_limit_size`` - Max size, in bytes, the total torrent size is

--- a/autotorrent/at.py
+++ b/autotorrent/at.py
@@ -549,7 +549,7 @@ class AutoTorrent(object):
             logger.info('Removing torrent %r' % path)
             os.remove(path)
 
-        if self.client.add_torrent(torrent, client_path, files['files'], fast_resume):
+        if self.client.add_torrent(torrent, client_path, destination_path, files['files'], fast_resume):
             self.print_status(Status.OK, path, 'Torrent added successfully')
             return Status.OK
         else:

--- a/autotorrent/at.py
+++ b/autotorrent/at.py
@@ -54,10 +54,11 @@ class IllegalPathException(Exception):
     pass
 
 class AutoTorrent(object):
-    def __init__(self, db, client, store_path, add_limit_size, add_limit_percent, delete_torrents, link_type='soft'):
+    def __init__(self, db, client, store_path, client_path, add_limit_size, add_limit_percent, delete_torrents, link_type='soft'):
         self.db = db
         self.client = client
         self.store_path = store_path
+        self.client_path = client_path
         self.add_limit_size = add_limit_size
         self.add_limit_percent = add_limit_percent
         self.delete_torrents = delete_torrents
@@ -525,6 +526,7 @@ class AutoTorrent(object):
         if files['mode'] == 'link' or files['mode'] == 'hash':
             logger.info('Preparing torrent using link mode')
             destination_path = os.path.join(self.store_path, os.path.splitext(os.path.basename(path))[0])
+            client_path = os.path.join(self.client_path, os.path.splitext(os.path.basename(path))[0])
 
             if os.path.isdir(destination_path):
                 logger.info('Folder exist but torrent is not seeded %s' % destination_path)
@@ -535,6 +537,7 @@ class AutoTorrent(object):
         elif files['mode'] == 'exact':
             logger.info('Preparing torrent using exact mode')
             destination_path = files['source_path']
+            client_path = files['source_path']
 
         fast_resume = True
         if files['mode'] == 'hash':
@@ -546,7 +549,7 @@ class AutoTorrent(object):
             logger.info('Removing torrent %r' % path)
             os.remove(path)
 
-        if self.client.add_torrent(torrent, destination_path, files['files'], fast_resume):
+        if self.client.add_torrent(torrent, client_path, files['files'], fast_resume):
             self.print_status(Status.OK, path, 'Torrent added successfully')
             return Status.OK
         else:

--- a/autotorrent/clients/_base.py
+++ b/autotorrent/clients/_base.py
@@ -30,7 +30,7 @@ class BaseClient(object):
         """
         raise NotImplementedError
 
-    def add_torrent(self, torrent, destination_path, files, fast_resume=True):
+    def add_torrent(self, torrent, destination_path, file_path, files, fast_resume=True):
         """
         Adds a torrent to the torrent client.
         """

--- a/autotorrent/clients/deluge.py
+++ b/autotorrent/clients/deluge.py
@@ -116,7 +116,7 @@ class DelugeClient(BaseClient):
         result = self.rpcclient.call('core.get_torrents_status', {}, ['name'])
         return set(x.lower() for x in result.keys())
 
-    def add_torrent(self, torrent, destination_path, files, fast_resume=True):
+    def add_torrent(self, torrent, destination_path, file_path, files, fast_resume=True):
         """
         Add a new torrent to Deluge.
 

--- a/autotorrent/clients/qbittorrent.py
+++ b/autotorrent/clients/qbittorrent.py
@@ -79,7 +79,7 @@ class QBittorrentClient(BaseClient):
         self._login_check()
         return set(torrent['hash'].lower() for torrent in self._session.get(urljoin(self.url, 'api/v2/torrents/info')).json())
 
-    def add_torrent(self, torrent, destination_path, files, fast_resume=True):
+    def add_torrent(self, torrent, destination_path, file_path, files, fast_resume=True):
         """
         Add a new torrent to qBittorrent.
 

--- a/autotorrent/clients/rtorrent.py
+++ b/autotorrent/clients/rtorrent.py
@@ -172,19 +172,19 @@ class RTorrentClient(BaseClient):
                 logger.info('This torrent is incomplete, setting bitfield')
                 torrent[b'libtorrent_resume'][b'bitfield'] = bitfield_to_string(bitfield)
 
-        torrent_file = os.path.join(file_path, '__tmp_torrent%s.torrent' % uuid.uuid4())
-        with open(torrent_file, 'wb') as f:
+        torrent_file = '__tmp_torrent%s.torrent' % uuid.uuid4()
+        with open(os.path.join(file_path, torrent_file), 'wb') as f:
             f.write(bencode(torrent))
 
         infohash = hashlib.sha1(bencode(torrent[b'info'])).hexdigest()
 
         if 'load.start' in self.get_methods():
-            cmd = [torrent_file, 'd.directory_base.set="%s"' % os.path.abspath(destination_path)]
+            cmd = [os.path.join(destination_path, torrent_file), 'd.directory_base.set="%s"' % os.path.abspath(destination_path)]
             cmd.append('d.custom1.set=%s' % quote(self.label))
             logger.info('Sending to rtorrent: %r' % cmd)
             self.proxy.load.start('', *cmd)
         else:
-            cmd = [torrent_file, 'd.set_directory_base="%s"' % os.path.abspath(destination_path)]
+            cmd = [os.path.join(destination_path, torrent_file), 'd.set_directory_base="%s"' % os.path.abspath(destination_path)]
             cmd.append('d.set_custom1=%s' % quote(self.label))
             logger.info('Sending to rtorrent: %r' % cmd)
             self.proxy.load_start(*cmd)
@@ -199,6 +199,6 @@ class RTorrentClient(BaseClient):
         else:
             logger.warning('Torrent was not added to rtorrent within reasonable timelimit')
 
-        os.remove(torrent_file)
+        os.remove(os.path.join(file_path, torrent_file))
 
         return successful

--- a/autotorrent/clients/rtorrent.py
+++ b/autotorrent/clients/rtorrent.py
@@ -124,7 +124,7 @@ class RTorrentClient(BaseClient):
     def _get_mtime(self, path):
         return int(os.stat(path).st_mtime)
 
-    def add_torrent(self, torrent, destination_path, files, fast_resume=True):
+    def add_torrent(self, torrent, destination_path, file_path, files, fast_resume=True):
         """
         Add a new torrent to rtorrent.
 
@@ -151,7 +151,7 @@ class RTorrentClient(BaseClient):
 
                 result = {b'priority': 1, b'completed': int(f['completed'])}
                 if f['completed']:
-                    result[b'mtime'] = self._get_mtime(os.path.join(destination_path, *f['path']))
+                    result[b'mtime'] = self._get_mtime(os.path.join(file_path, *f['path']))
                 torrent[b'libtorrent_resume'][b'files'].append(result)
 
                 last_position = current_position + f['length']
@@ -172,7 +172,7 @@ class RTorrentClient(BaseClient):
                 logger.info('This torrent is incomplete, setting bitfield')
                 torrent[b'libtorrent_resume'][b'bitfield'] = bitfield_to_string(bitfield)
 
-        torrent_file = os.path.join(destination_path, '__tmp_torrent%s.torrent' % uuid.uuid4())
+        torrent_file = os.path.join(file_path, '__tmp_torrent%s.torrent' % uuid.uuid4())
         with open(torrent_file, 'wb') as f:
             f.write(bencode(torrent))
 

--- a/autotorrent/clients/transmission.py
+++ b/autotorrent/clients/transmission.py
@@ -117,7 +117,7 @@ class TransmissionClient(BaseClient):
         result = self.call('torrent-get', fields=['hashString'])
         return set(x['hashString'].lower() for x in result['torrents'])
 
-    def add_torrent(self, torrent, destination_path, files, fast_resume=True):
+    def add_torrent(self, torrent, destination_path, file_path, files, fast_resume=True):
         """
         Add a new torrent to Transmission.
 

--- a/autotorrent/cmd.py
+++ b/autotorrent/cmd.py
@@ -170,11 +170,13 @@ def commandline_handler():
     client_options = dict(config.items(client_option))
     client_options.pop('client')
     client = TORRENT_CLIENTS[client_name](**client_options)
+    store_path = config.get('general', 'store_path')
     
     at = AutoTorrent(
         db,
         client,
-        config.get('general', 'store_path'),
+        store_path,
+        (config.get('general', 'client_path') if config.has_option('general', 'client_path') else store_path),
         config.getint('general', 'add_limit_size'),
         config.getfloat('general', 'add_limit_percent'),
         args.delete_torrents,


### PR DESCRIPTION
This allows for a torrent client to have a different base path, for example if the client is inside a docker container and has a different mapping. 

Related to #33 and possibly #26